### PR TITLE
Fixed link to "fluidsynth"

### DIFF
--- a/soundfont-generator/sf2-piano.sh
+++ b/soundfont-generator/sf2-piano.sh
@@ -4,7 +4,7 @@
 # ------------------------------------
 # nodejs     - http://nodejs.org/
 # gzip       - http://www.gzip.org/
-# fluidsynth - http://www.audiosoftstore.com/downloads.html
+# fluidsynth - http://sourceforge.net/apps/trac/fluidsynth/
 # oggenc     - http://www.rarewares.org/ogg-oggenc.php
 # lame       - http://lame.sourceforge.net/
 


### PR DESCRIPTION
It looks like the link to audiosoftstore.com is actually for a tool called "midi2mp3", which isn't actually used.
