### PR TITLE
Add cofing options to override paths to soundManager js/swf files

### DIFF
--- a/js/MIDI/LoadPlugin.js
+++ b/js/MIDI/LoadPlugin.js
@@ -72,7 +72,7 @@ connect.flash = function(filetype, instruments, conf) {
 	// fairly quick, but requires loading of individual MP3s (more http requests).
 	if (MIDI.loader) MIDI.loader.message("Flash API...");
 	DOMLoader.script.add({
-		src: "./inc/SoundManager2/script/soundmanager2.js",
+		src: conf.soundManagerUrl || "./inc/SoundManager2/script/soundmanager2.js",
 		verify: "SoundManager",
 		callback: function () {
 			MIDI.Flash.connect(conf);

--- a/js/MIDI/Plugin.js
+++ b/js/MIDI/Plugin.js
@@ -427,7 +427,7 @@ if (window.Audio) (function () {
 	root.connect = function (conf) {
 		soundManager.flashVersion = 9;
 		soundManager.useHTML5Audio = true;
-		soundManager.url = '../inc/SoundManager2/swf/';
+		soundManager.url = conf.soundManagerSwfUrl || '../inc/SoundManager2/swf/';
 		soundManager.useHighPerformance = true;
 		soundManager.wmode = 'transparent';
 		soundManager.flashPollingInterval = 1;


### PR DESCRIPTION
Added soundManagerUrl + soundManagerSwfUrl config options that can be passed to loadPlugin() to override paths to soundManager js/swf files
