### PR TITLE
Remove accidental header in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ DEMOS
 * <a href="http://spiral.qet.me/">Spiral Keyboard</a> by Patrick Snels
 * <a href="http://online-compute.rhcloud.com/ragamroll/">Ragamroll</a> by Mani Balasubramanian
 * <a href="http://www.earbuilder.com/">Ear Builder</a> by Antti Kaihola
+
 -------------
 
 * <a href="./js/MIDI.loadPlugin.js">MIDI.loadPlugin.js</a>: Decides which framework is best to use, and sends request.


### PR DESCRIPTION
There's a little screwup in the README -- by omitting the newline before the horizontal divider the line "Ear Builder by Antti Kaihola" becomes a gigantic header.
