### PR TITLE
let the choice of audio type

### DIFF
--- a/js/MIDI/LoadPlugin.js
+++ b/js/MIDI/LoadPlugin.js
@@ -8,6 +8,7 @@
 		instrument: "acoustic_grand_piano", // or 1 (default)
 		instruments: [ "acoustic_grand_piano", "acoustic_guitar_nylon" ], // or multiple instruments
 		callback: function() { }
+		limitedNetwork: True|False // In case of mobile usage
 	});
 */
 
@@ -56,7 +57,11 @@ MIDI.loadPlugin = function(conf) {
 		///
 		if (!connect[api]) return;
 		// use audio/ogg when supported
-		var filetype = types["audio/ogg"] ? "ogg" : "mp3";
+		if (typeof (conf.limitedNetwork) !== "undefined" && conf.limitedNetwork === true) {
+			var filetype = "mp3"
+		}
+		else
+			var filetype = types["audio/ogg"] ? "ogg" : "mp3";
 		// load the specified plugin
 		connect[api](filetype, instruments, conf);
 	});


### PR DESCRIPTION
In case of the user can play ogg and mp3 but is using a smartphone it can be useful to use mp3 instead of ogg to minimize network traffic.
