### PR TITLE
Make MIDI.js "play nice" when other libraries are also present.

### DIFF
--- a/js/MIDI/LoadPlugin.js
+++ b/js/MIDI/LoadPlugin.js
@@ -166,7 +166,9 @@ var createQueue = function(conf) {
 	var self = {};
 	self.queue = [];
 	for (var key in conf.items) {
-		self.queue.push(conf.items[key]);
+		if (conf.items.hasOwnProperty(key)) {
+			self.queue.push(conf.items[key]);
+		}
 	}
 	self.getNext = function() {
 		if (!self.queue.length) return conf.onComplete();


### PR DESCRIPTION
Specifically, this allows ImpactJS to run alongside MIDI.js, although any library which extends the Array prototype will benefit from this fix. Related: http://impactjs.com/forums/impact-engine/array-prototype-fix
