### PR TITLE
Added program change detection

### DIFF
--- a/js/MIDI/LoadPlugin.js
+++ b/js/MIDI/LoadPlugin.js
@@ -65,6 +65,8 @@ MIDI.loadPlugin = function(conf) {
 		MIDI.supports = types;
 		connect[api](filetype, instruments, conf);
 	});
+
+	MIDI.detectProgramChange = conf.detectProgram || false;
 };
 
 ///

--- a/js/MIDI/Player.js
+++ b/js/MIDI/Player.js
@@ -235,6 +235,15 @@ var startAudio = function (currentTime, fromCache) {
 					interval: scheduleTracking(channel, note, queuedTime, offset, 128)
 				});
 				break;
+			case 'programChange':
+				if(MIDI.detectProgramChange) {
+					eventQueue.push({
+						event: event,
+						source: MIDI.programChange(channel, event.programNumber),
+						interval: scheduleTracking(channel, note, queuedTime, offset, 128)
+					});
+				}
+				break;
 			default:
 				break;
 		}


### PR DESCRIPTION
I thought that it might be useful to be able to actually use the instruments proposed in the midi file. This modification just passes program changes to MIDI.

Is there any good way to load only the instruments needed for the processed midi-file? Maybe iterating over all events once in the beginning and simply checking for programChange events?
