### PR TITLE
Documentation update

### DIFF
--- a/generator/ruby/soundfont_builder.rb
+++ b/generator/ruby/soundfont_builder.rb
@@ -10,7 +10,8 @@
 #   OggEnc (from vorbis-tools)
 #   Ruby Gem: midilib
 #
-#   $ brew install fluidsynth vorbis-tools lame (on OSX)
+#   $ brew install --with-libsndfile fluidsynth (on OSX)
+#   $ brew install vorbis-tools lame
 #   $ gem install midilib
 #
 # You'll need to download a GM soundbank to generate audio.


### PR DESCRIPTION
Fluidsynth needs libsndfile support to render anything other than raw files which will make this script fail with the problem discussed here: https://github.com/mudcube/MIDI.js/issues/37

To avoid that workaround, fluidsynth needs to be installed with libsndfile support so it will render actual wav files which will be recognised by lame and oggenc without explicitly stating input format.