### PR TITLE
Changed the grunt unglify version to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "devDependencies": {
     "grunt": "~0.4.0",
     "grunt-contrib-concat": "~0.1.3",
-    "grunt-contrib-uglify": "~0.1.2"
+    "grunt-contrib-uglify": "~0.9.2"
   }
 }


### PR DESCRIPTION
I updated the grunt-contrib-uglify to 0.9.2. The previous version failed to unglify on my windows 10. Is there any reason to work with the not-so-new 0.1.2 version?
