### PR TITLE
Update uglify version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "devDependencies": {
     "grunt": "~0.4.0",
-    "grunt-contrib-concat": "~0.1.3",
-    "grunt-contrib-uglify": "~0.9.2"
+    "grunt-contrib-uglify": "~0.9.2",
+    "grunt-contrib-concat": "~0.1.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "devDependencies": {
     "grunt": "~0.4.0",
     "grunt-contrib-concat": "~0.1.3",
-    "grunt-contrib-uglify": "~0.1.2"
+    "grunt-contrib-uglify": "~0.9.2"
   }
 }


### PR DESCRIPTION
Changed the grunt uglify version to the latest. The previous version failed to uglify on my windows 10 machine. Is there any reason to use the old version?
