### PR TITLE
Updating uglify version and polyfill concat paths.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,8 +27,8 @@ module.exports = function (grunt) {
 				'js/util/dom_request_xhr.js', // req when using XHR
 				'js/util/dom_request_script.js', // req otherwise
 //				'js/widget/loader.js', // optional
-				'inc/polyfill/Base64.js',
-				'inc/polyfill/base64binary.js'
+				'inc/shim/Base64.js',
+				'inc/shim/base64binary.js'
 			]
 		},
 		uglify: {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "devDependencies": {
     "grunt": "~0.4.0",
     "grunt-contrib-concat": "~0.1.3",
-    "grunt-contrib-uglify": "~0.1.2"
+    "grunt-contrib-uglify": "~1.0.1"
   }
 }


### PR DESCRIPTION
## Hallo!

I was trying to play around with this awesome project but ran into a few issues so I figured to do the neighborly thing and fork your repo!

When I was running `npm install` everything was peachy, but when running `grunt` I was getting this error: `Warnings: Cannot assign to read only property 'subarray' ...`. After some researching I realized it was just because the `grunt-contrib-uglify` package wasn't updated.

I also noticed that in the `concat` grunt task that it is trying to concat: 
- `inc/polyfill/Base64.js` 
- `inc/polyfill/base64binary.js` 

but concat fails silently and does not end up including these files because they truly live in `inc/shim/` which was giving me an error when actually trying to use MIDI.js in the browser.

When I updated the paths to `inc/shim/` everything was great! 😸 

I hope this seems legit to you. 🙇 
