### PR TITLE
Use channel 10 for percussion

### DIFF
--- a/generator/ruby/soundfont_builder.rb
+++ b/generator/ruby/soundfont_builder.rb
@@ -34,9 +34,11 @@ SOUNDFONT = "../sf2/redco/TR-808-Drums.SF2" # Soundfont file path
 # This script will generate MIDI.js-compatible instrument JS files for
 # all instruments in the below array. Add or remove as necessary.
 INSTRUMENTS = [
+  -1,   # Percussion (channel 10)
   0     # Acoustic Grand Piano
 ];
 # INSTRUMENTS = [
+#   -1,    # Percussion (channel 10)
 #   0,     # Acoustic Grand Piano
 #   24,    # Acoustic Guitar (nylon)
 #   25,    # Acoustic Guitar (steel)
@@ -64,7 +66,11 @@ puts "Building the following instruments using font: " + SOUNDFONT
 
 # Display instrument names.
 INSTRUMENTS.each do |i|
-  puts "    #{i}: " + MIDI::GM_PATCH_NAMES[i]
+  if i == -1
+    puts "    percussion (MIDI channel 10)"
+  else
+    puts "    #{i}: " + MIDI::GM_PATCH_NAMES[i]
+  end
 end
 
 puts
@@ -137,11 +143,16 @@ def generate_midi(program, note_value, file)
   include MIDI
   seq = Sequence.new()
   track = Track.new(seq)
+  channel = 0
+  if program == -1
+    channel = 9
+    program = 0
+  end
 
   seq.tracks << track
-  track.events << ProgramChange.new(0, Integer(program))
-  track.events << NoteOn.new(0, note_value, VELOCITY, 0) # channel, note, velocity, delta
-  track.events << NoteOff.new(0, note_value, VELOCITY, DURATION)
+  track.events << ProgramChange.new(channel, Integer(program))
+  track.events << NoteOn.new(channel, note_value, VELOCITY, 0) # channel, note, velocity, delta
+  track.events << NoteOff.new(channel, note_value, VELOCITY, DURATION)
 
   File.open(file, 'wb') { | file | seq.write(file) }
 end
@@ -183,7 +194,11 @@ end
 
 def generate_audio(program)
   include MIDI
-  instrument = GM_PATCH_NAMES[program]
+  if program == -1
+    instrument = "percussion"
+  else
+    instrument = GM_PATCH_NAMES[program]
+  end
   instrument_key = instrument.downcase.gsub(/[^a-z0-9 ]/, "").gsub(/\s+/, "_")
 
   puts "Generating audio for: " + instrument + "(#{instrument_key})"

--- a/js/midi/gm.js
+++ b/js/midi/gm.js
@@ -49,7 +49,8 @@
 		'Synth Effects': ['97 FX 1 (rain)', '98 FX 2 (soundtrack)', '99 FX 3 (crystal)', '100 FX 4 (atmosphere)', '101 FX 5 (brightness)', '102 FX 6 (goblins)', '103 FX 7 (echoes)', '104 FX 8 (sci-fi)'],
 		'Ethnic': ['105 Sitar', '106 Banjo', '107 Shamisen', '108 Koto', '109 Kalimba', '110 Bagpipe', '111 Fiddle', '112 Shanai'],
 		'Percussive': ['113 Tinkle Bell', '114 Agogo', '115 Steel Drums', '116 Woodblock', '117 Taiko Drum', '118 Melodic Tom', '119 Synth Drum'],
-		'Sound effects': ['120 Reverse Cymbal', '121 Guitar Fret Noise', '122 Breath Noise', '123 Seashore', '124 Bird Tweet', '125 Telephone Ring', '126 Helicopter', '127 Applause', '128 Gunshot']
+		'Sound effects': ['120 Reverse Cymbal', '121 Guitar Fret Noise', '122 Breath Noise', '123 Seashore', '124 Bird Tweet', '125 Telephone Ring', '126 Helicopter', '127 Applause', '128 Gunshot'],
+		'Percussion': ['0 Percussion'] // not really GM but convenient hack
 	});
 
 	/* get/setInstrument
@@ -138,6 +139,7 @@
 				solo: false
 			};
 		}
+		channels[9].instrument = -1; // channel 10 is percussion
 		return channels;
 	})();
 

--- a/js/midi/plugin.webaudio.js
+++ b/js/midi/plugin.webaudio.js
@@ -235,7 +235,7 @@
 			var notes = root.keyToNote;
 			for (var key in notes) urls.push(key);
 			///
-			var waitForEnd = function(instrument) {
+			var waitForEnd = function() {
 				for (var key in bufferPending) { // has pending items
 					if (bufferPending[key]) return;
 				}
@@ -259,7 +259,7 @@
 							var percent = index / 87;
 // 							console.log(MIDI.GM.byId[instrumentId], 'processing: ', percent);
 							soundfont.isLoaded = true;
-							waitForEnd(instrument);
+							waitForEnd();
 						}
 					}, function(err) {
 		// 				console.log(err);


### PR DESCRIPTION
This enables the generation of `percussion` as an “instrument” in the soundfont builder.  It also adds that instrument to our General Midi database, with ID 0 (one-based) resp. -1 (zero-based).  This does not really reflect the use in GM, but avoids a large number of case distinctions and appears mostly beneficial.  This instrument is pre-selected for channel 10 (one-based), to conform with GM usage.

The soundfont builder changes fix #91. This also addresses the core of #72, but perhaps we should prevent program changes on channel 10 to completely fix that. Doing so might break some existing applications, though, so another alternative might be suppressing program changes in the MIDI file player only.

Do we need to restrict the soundfont creation to those “notes” which actually have a percussion instrument associated with them? Currently I'm using the same range used for other instruments as well, and I don't see fluidsynth complaining.
