### PR TITLE
Simplify WebMIDI detection

### DIFF
--- a/js/midi/audioDetect.js
+++ b/js/midi/audioDetect.js
@@ -38,19 +38,9 @@ if (typeof MIDI === 'undefined') MIDI = {};
 	};
 
 	root.audioDetect = function(onsuccess) {
-		/// detect jazz-midi plugin
+		/// detect WebMIDI support, native or by jazz-midi plugin
 		if (navigator.requestMIDIAccess) {
-			var isNative = Function.prototype.toString.call(navigator.requestMIDIAccess).indexOf('[native code]');
-			if (isNative) { // has native midiapi support
-				supports['webmidi'] = true;
-			} else { // check for jazz plugin midiapi support
-				for (var n = 0; navigator.plugins.length > n; n ++) {
-					var plugin = navigator.plugins[n];
-					if (plugin.name.indexOf('Jazz-Plugin') >= 0) {
-						supports['webmidi'] = true;
-					}
-				}
-			}
+			supports['webmidi'] = true;
 		}
 
 		/// check whether <audio> tag is supported


### PR DESCRIPTION
The previous code is broken: the result of `indexOf` is an index, and `-1` if the searched string is not found.  So the value will be non-zero (and therefore thuthy) in all realistic setups, making the plugin enumeration an unused code branch.

We _could_ fix the intent of the original code, by comparing the `indexOf` result against `-1`.  But doing so would break systems where WebMIDI is provided by some other plugin or polyfill, where plugins cannot be enumerated, where native functions stringify in some other way, where something monkey-patched the method in question, or something like that.

So instead this commit here relies on the ducktyping philosophy: if there is a `navigator.requestMIDIAccess` method, we assume it does the right thing and avoid further checks.  This is what the current code is essentially doing right now anyway, even though not intentionally.
