### PR TITLE
Consistently use webkitAudioContext as an alias for AudioContext

### DIFF
--- a/js/midi/loader.js
+++ b/js/midi/loader.js
@@ -55,9 +55,9 @@ MIDI.Player = MIDI.Player || {};
 				api = hash.substr(1);
 			} else if (supports.webmidi) {
 				api = 'webmidi';
-			} else if (window.AudioContext) { // Chrome
+			} else if (window.AudioContext || window.webkitAudioContext) {
 				api = 'webaudio';
-			} else if (window.Audio) { // Firefox
+			} else if (window.Audio) {
 				api = 'audiotag';
 			}
 

--- a/js/midi/plugin.webaudio.js
+++ b/js/midi/plugin.webaudio.js
@@ -8,7 +8,7 @@
 
 (function(root) { 'use strict';
 
-	window.AudioContext && (function() {
+	(window.AudioContext || window.webkitAudioContext) && (function() {
 		var audioContext = null; // new AudioContext();
 		var useStreamingBuffer = false; // !!audioContext.createMediaElementSource;
 		var midi = root.WebAudio = {api: 'webaudio'};

--- a/js/midi/plugin.webmidi.js
+++ b/js/midi/plugin.webmidi.js
@@ -64,9 +64,9 @@
 	midi.connect = function(opts) {
 		root.setDefaultPlugin(midi);
 		var errFunction = function(err) { // well at least we tried!
-			if (window.AudioContext) { // Chrome
+			if (window.AudioContext || window.webkitAudioContext) {
 				opts.api = 'webaudio';
-			} else if (window.Audio) { // Firefox
+			} else if (window.Audio) {
 				opts.api = 'audiotag';
 			} else { // no support
 				return;


### PR DESCRIPTION
MIDI.js does consider `webkitAudioContext` as an alternative to `AudioContext` in _some_ places, but not consistently so far. The commit at hand changes that. This is required to support WebAudio on Safari at least till version 10, see http://caniuse.com/#feat=audio-api for use of this prefix.
